### PR TITLE
Update - If error just display french message

### DIFF
--- a/frontend/src/views/AuthView.vue
+++ b/frontend/src/views/AuthView.vue
@@ -68,7 +68,7 @@ const handleLogin = async () => {
       error.value = 'Votre compte est en attente de validation par un administrateur.';
     }
   } catch (err: any) {
-    error.value = err.message || 'Échec de la connexion. Vérifiez vos identifiants.';
+    error.value = 'Échec de la connexion. Vérifiez vos identifiants.';
   } finally {
     isLoading.value = false;
   }


### PR DESCRIPTION
Changement justep our le Invalid Credentials. Le fait d'utiliser || fait que si il y a un message d'erreur il est affiché à la place de notre message. Dans tous les cas je ne pense pas que les user ont besoin de savoir le pourquoi du comment. Donc juste afficher que c'est incorrect. On retrouve pas mal de  err.message || dans l'admin view et l'auth pour l'instant ça ne devrait pas poser de problème.